### PR TITLE
CRC32 calculation shouldn't crash on low-end boxes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gem "parseconfig"
 gem "nzb", '>=0.2.2'
 gem "RubyInline"
 gem "speedometer", '>=0.0.5'
+gem 'vmstat', '2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
     nzb (0.2.2)
     parseconfig (1.0.4)
     speedometer (0.0.5)
+    vmstat (2.1.0)
 
 PLATFORMS
   ruby
@@ -16,3 +17,4 @@ DEPENDENCIES
   nzb (>= 0.2.2)
   parseconfig
   speedometer (>= 0.0.5)
+  vmstat (= 2.1.0)

--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ View help:
 CREDITS
 =======
 * nntp library(crudely modified by me) from http://nntp.rubyforge.org/ project.
-* crc32 method from yenc gem by Sam "madgeekfiend" Contapay(https://github.com/madgeekfiend/yenc)
+* [Sam "madgeekfiend" Contapay](https://github.com/madgeekfiend) for inspiration/ideas from his [yEnc](https://github.com/madgeekfiend/yenc) project.
 * thread-pool library from https://gist.github.com/Burgestrand/2040175
 * [john3voltas](https://github.com/john3voltas) for helping with excess authentication bug(fixed in v0.51).
 
 HISTORY
 =======
+* 0.52 - CRC32 calculation won't crash the program on low-end boxes.
 * 0.51 - Won't be trying to log in 2nd time if already authenticated.
 * 0.50 - Rewrote big part of the code. New libraries. More stable speed.
 * 0.48 - Got rid of memory leaks.

--- a/sanguinews.rb
+++ b/sanguinews.rb
@@ -17,7 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ########################################################################
 
-@version = '0.51'
+@version = '0.52'
 
 require 'rubygems'
 require 'bundler/setup'
@@ -256,6 +256,7 @@ end
 # let's give a little bit higher priority for file processing thread
 @t = Thread.new {
   files_to_process.each do |file|
+    @s.log("Calculating CRC32 value for #{file.name}\n") if @verbose
     file.file_crc32
     @s.log("Encoding #{file.name}\n")
     yencode(file, @length, messages)


### PR DESCRIPTION
Fixed crashes when processing veeery large files on low-end machines.
