### PR TITLE
Updated install instructions to include ruby.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Because of some C code, C compiler is needed(GCC or Apple's clang). On Debian-ba
 
 Debian systems need also additional ruby development headers:
 
-    apt-get install ruby-dev
+    apt-get install ruby ruby-dev
 
 Now you can simply install `sanguinews` as a gem:
 


### PR DESCRIPTION
On a plain Debian 8.2 minimal installation, ruby needs to be installed aswell. Otherwise "ruby" and "gem" are not available.
