### PR TITLE
Rearranged config file checks before arg checks

### DIFF
--- a/lib/sanguinews/config.rb
+++ b/lib/sanguinews/config.rb
@@ -137,8 +137,6 @@ module Sanguinews
       @data[:recursive] = false
       @data[:files] = []
 
-      parse_options!(args)
-
       # Parse options in config file
       if @data[:config] && File.exist?(File.expand_path(@data[:config]))
 	config = @data[:config]
@@ -151,6 +149,10 @@ module Sanguinews
       else
 	config_gen
       end
+
+      # Parse options from command line
+      parse_options!(args)
+
     end
   
   end


### PR DESCRIPTION
Rearranged the checks for an existing config file.

I find it much more convenient to check for an existing config file, before checking
command line arguments. This allows the user to simply run "sanguinews" to generate
a stub config file, before actually uploading a file.

The user most likely wants to configure sanguinews, before he actually wants to upload anything.
